### PR TITLE
Change the link of google_python_style.vim

### DIFF
--- a/google-python-styleguide/background.rst
+++ b/google-python-styleguide/background.rst
@@ -3,4 +3,4 @@
 
 Python 是 Google主要的脚本语言。这本风格指南主要包含的是针对python的编程准则。
 
-为帮助读者能够将代码准确格式化，我们提供了针对 `Vim的配置文件  <http://google-styleguide.googlecode.com/svn/trunk/google_python_style.vim>`_ 。对于Emacs用户，保持默认设置即可。
+为帮助读者能够将代码准确格式化，我们提供了针对 `Vim的配置文件  <https://github.com/google/styleguide/blob/gh-pages/google_python_style.vim>`_ 。对于Emacs用户，保持默认设置即可。


### PR DESCRIPTION
The former link [http://google-styleguide.googlecode.com/svn/trunk/google_python_style.vim](http://google-styleguide.googlecode.com/svn/trunk/google_python_style.vim) is 404. Update it to the [new](https://github.com/google/styleguide/blob/gh-pages/google_python_style.vim) one from official github account of google