### PR TITLE
fix a small mistake in google-cpp-styleguide/nameing.rst file

### DIFF
--- a/google-cpp-styleguide/naming.rst
+++ b/google-cpp-styleguide/naming.rst
@@ -54,7 +54,7 @@
 
 * ``myusefulclass.cc``
 
-* ``muusefulclass_test.cc`` // ``_unittest`` 和 ``_regtest`` 已弃用.
+* ``myusefulclass_test.cc`` // ``_unittest`` 和 ``_regtest`` 已弃用.
 
 C++ 文件要以 ``.cc`` 结尾, 头文件以 ``.h`` 结尾. 专门插入文本的文件则以 ``.inc`` 结尾, 参见 :ref:`头文件自足 <self-contained-headers>`.
 


### PR DESCRIPTION
发现google-cpp-styleguide/nameing.rst文件里面的一个小错误。