### PR TITLE
fix latex and latexpdf error, issue #63

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -30,6 +30,7 @@ html_title = u'Google 开源项目风格指南'
 htmlhelp_basename = 'google-styleguide'
 html_add_permalinks = None
 
+latex_engine = 'xelatex'
 file_insertion_enabled = False
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:    
@@ -64,7 +65,7 @@ else:
         'preamble' : r'''        \usepackage{ctex}        ''',    
     }  
 latex_documents = [
-  ('index', 'google-styleguide.tex', u'Google 开源项目风格指南',
+  ('contents', 'google-styleguide.tex', u'Google 开源项目风格指南',
    u'', 'manual'),
 ]
 


### PR DESCRIPTION
我注意到 #63 这个问题是由于配置文件的一个小意外造成的, 所以进行了更新.
另外, 由于 tex 的问题, 实测本地需要 texlive2016 或以上版本的 xetex 引擎才能正确编译, 故更换了 tex 引擎.
ref: commit [68f1e2d](https://github.com/zh-google-styleguide/zh-google-styleguide/commit/68f1e2de530fd6e1cc0d4108f3b69f573c19333a)