### PR TITLE
Revise doc links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,16 +22,17 @@ Google 开源项目风格指南 (中文版)
 
 我们已经发布了五份 **中文版** 的风格指南:
 
-#. `Google C++ 风格指南 <http://zh-google-styleguide.readthedocs.org/en/latest/google-cpp-styleguide/>`_
+#. `Google C++ 风格指南 <https://google-styleguide.readthedocs.io/zh_CN/latest/google-cpp-styleguide/contents.html>`_
 
-#. `Google Objective-C 风格指南 <http://zh-google-styleguide.readthedocs.org/en/latest/google-objc-styleguide/>`_
+#. `Google Objective-C 风格指南 <https://google-styleguide.readthedocs.io/zh_CN/latest/google-objc-styleguide/contents.html>`_
 
-#. `Google Python 风格指南 <http://zh-google-styleguide.readthedocs.org/en/latest/google-python-styleguide/>`_
+#. `Google Python 风格指南 <https://google-styleguide.readthedocs.io/zh_CN/latest/google-python-styleguide/contents.html>`_
+
+#. `Google JavaScript 风格指南 <https://google-styleguide.readthedocs.io/zh_CN/latest/google-javascript-styleguide/contents.html>`_
+
+#. `Google Shell 风格指南 <https://google-styleguide.readthedocs.io/zh_CN/latest/google-shell-styleguide/contents.html>`_
 
 #. `Google JSON 风格指南 <https://github.com/darcyliu/google-styleguide/blob/master/JSONStyleGuide.md>`_
-
-#. `Google Shell 风格指南 <http://zh-google-styleguide.readthedocs.org/en/latest/google-shell-styleguide/>`_
-
 
 中文版项目采用 reStructuredText 纯文本标记语法, 并使用 Sphinx 生成 HTML / CHM / PDF 等文档格式.
 


### PR DESCRIPTION
> #120 里修改了 README 中的在线阅读的地址，但没有修改相应的风格指南地址。

修改了 README 中已有的风格指南地址，并添加了 JavaScript 的风格指南地址。